### PR TITLE
Improve coverage and project docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install 1Password CLI
+        shell: pwsh
+        run: |
+          winget install --id AgileBits.1Password.CLI --exact --accept-source-agreements --accept-package-agreements
+          op --version
+
       - name: Install Pester
         shell: pwsh
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install 1Password CLI
+        uses: 1password/install-cli-action@v4
+
+      - name: Verify 1Password CLI
         shell: pwsh
-        run: |
-          winget install --id AgileBits.1Password.CLI --exact --accept-source-agreements --accept-package-agreements
-          op --version
+        run: op --version
 
       - name: Install Pester
         shell: pwsh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,9 @@ PowerShell scripts for administrative management of a 1Password vault. They run 
 
 - [1Password CLI](https://developer.1password.com/docs/cli) installed and on `PATH`
 - An active `op` session (`op signin`)
-- Windows PowerShell 5.1 (scripts use `.ps1` syntax and are not tested on PowerShell 7+)
+- Windows PowerShell 5.1 for script compatibility
+- PowerShell 7+ is supported for development tooling and used by CI
+- Pester 5+ for unit tests and coverage
 
 ## Repository layout
 
@@ -19,8 +21,12 @@ Add-Rotation-Fields.ps1        # Setup: add rotation metadata to logins
 Get-Stale-Items.ps1            # Audit: logins overdue for a password change
 New-Item-Password.ps1          # Action: generate a new password for one item
 Get-All-Items-Extended.ps1     # Export: full vault export with security metadata
+scripts/
+  Lint.ps1                     # PSScriptAnalyzer wrapper
+  Test.ps1                     # Pester 5 test and coverage wrapper
 tests/
-  Utils.Tests.ps1              # Pester 3.4.0 unit tests for Utils.ps1
+  Utils.Tests.ps1              # Pester 5 unit tests for Utils.ps1
+codecov.yml                    # Codecov PR comments and coverage targets
 ```
 
 ## Scripts
@@ -97,7 +103,7 @@ Output is a table sorted by `DaysSinceUpdate` descending.
 ### `New-Item-Password.ps1`
 Generates a new password for a single item and updates its `last password update` date to today.
 
-The password recipe is read from a custom `password recipe` field on the item. If that field is absent, the default recipe `letters,digits,symbols,32` is used. Recipe format is the same comma-separated string accepted by the `op --generate-password` flag, with one extension: a recipe containing `words` triggers local memorable-password generation (see [Memorable passwords](#memorable-passwords)) since the CLI does not support word-based generation natively.
+The password recipe is read from a custom `password recipe` field on the item. If that field is absent, the default recipe `words,digits,symbols,32` is used. Recipe format is the same comma-separated string accepted by the `op --generate-password` flag, with one extension: a recipe containing `words` triggers local memorable-password generation (see [Memorable passwords](#memorable-passwords)) since the CLI does not support word-based generation natively.
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
@@ -118,10 +124,11 @@ Every script dot-sources `Utils.ps1` at the top via `. "$PSScriptRoot\Utils.ps1"
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `Get-VaultItems` | `-Vault -Categories[] [-Tag] [-Long]` | Wraps `op item list`; returns parsed JSON array |
-| `Get-ItemDetail` | `-Id [-Vault]` | Wraps `op item get`; returns parsed JSON object for one item |
-| `Get-ItemDetails` | `-Items [-ThrottleLimit=10]` | Fetches full details for a list of items **in parallel** using a runspace pool; returns `@{Login, Details}` pairs |
+| `Get-ItemDetail` | `-Id [-Vault] [-MaxRetries=3] [-RetryDelayMs=1000]` | Wraps `op item get`; retries transient CLI/Desktop App errors and returns parsed JSON for one item |
+| `Test-OpTransientError` | `-Message` | Detects retryable `op` errors such as timeouts, Desktop App connection issues, or temporary unavailability |
+| `Get-ItemDetails` | `-Items [-ThrottleLimit=10] [-MaxRetries=3] [-RetryDelayMs=1000]` | Fetches full details for a list of items **in parallel** using a runspace pool; returns `@{Login, Details}` pairs |
 
-`Get-ItemDetails` is the performance-critical path. It creates a `RunspacePool` with up to `ThrottleLimit` concurrent threads, fans out all `op item get` calls simultaneously, polls for completion with a `Write-Progress` bar, then collects results. Write operations (`op item edit`) are always kept sequential to avoid concurrent vault mutations.
+`Get-ItemDetails` is the performance-critical path. It creates a `RunspacePool` with up to `ThrottleLimit` concurrent threads, fans out all `op item get` calls simultaneously, polls for completion with a `Write-Progress` bar, then collects results. Transient failures are retried sequentially through `Get-ItemDetail`; non-transient failures are warned and skipped. Write operations (`op item edit`) are always kept sequential to avoid concurrent vault mutations.
 
 ### Item field helpers
 
@@ -153,7 +160,7 @@ The `last password update` field in 1Password stores its value as a Unix timesta
 | `Get-PasswordRecipe` | `-Details -Default` | Returns the value of the `password recipe` field, or `Default` if the field is absent |
 | `Test-ItemSso` | `-Details -SsoTag` | Returns `$true` if the item has a `sign in with` field or the given SSO tag |
 | `Test-ItemMfa` | `-Details -MfaTag` | Returns `$true` if the item carries the given MFA tag |
-| `Get-ItemExtendedInfo` | `-Details -ExcludePattern -SsoTag -MfaTag` | Returns a `PSCustomObject {Title, Username, Category, Id, Vault, Security, Recipe, LastPwUpdate, DaysSince}` for one item, or `$null` for excluded items. Falls back to `created_at` when no rotation field exists |
+| `Get-ItemExtendedInfo` | `-Details -ExcludePattern -SsoTag -MfaTag` | Returns a `PSCustomObject {Title, Username, Category, Tags, Id, Vault, Security, Recipe, LastPwUpdate, DaysSince}` for one item, or `$null` for excluded items. Falls back to `created_at` when no rotation field exists |
 
 ### Password generation
 
@@ -192,22 +199,41 @@ The scripts read and write the following custom fields by label:
 | `secure*` | Any secure tag; treated as non-significant for untagged detection |
 | `finance`, `main` | Rotation cadence tags (90-day cycle) |
 
-## Testing
+## Testing and coverage
 
-Tests use **Pester 3.4.0** (the version pre-installed with Windows PowerShell). Do not use Pester 5 syntax (`Should -Be`, top-level `BeforeAll`, `-ForEach` on `It`) — it will fail on the system Pester. See [issue #5](https://github.com/michaelconan/1password-review-scripts/issues/5) for the upgrade plan.
+Tests use **Pester 5+**. Use modern Pester constructs such as `BeforeAll`, `BeforeEach`, and `Should -Be`; legacy syntax compatibility is no longer required.
 
 Run the suite:
 
 ```powershell
-Invoke-Pester -Path tests\Utils.Tests.ps1
+.\scripts\Test.ps1
+.\scripts\Test.ps1 -IncludeCoverage
 ```
 
-36 tests cover all functions in `Utils.ps1` except the two thin `op` CLI wrappers (`Get-VaultItems`, `Get-ItemDetail`) and the parallel fetcher (`Get-ItemDetails`), which are integration concerns. Business logic functions are tested with plain `PSCustomObject` fixtures — no mocking of external commands required.
+`scripts\Test.ps1` creates `coverage/` when needed, runs all tests under `tests/`, writes `coverage/test-results.xml`, and, with `-IncludeCoverage`, writes `coverage/coverage.xml`, `coverage/summary.txt`, and `coverage/missed-commands.txt`. The script disables Pester's built-in test-result exporter and writes a small JUnit-style XML file itself because Pester's exporter can call Windows environment probes that fail under restricted runners.
+
+The coverage target is **80%** for `Utils.ps1`; `scripts\Test.ps1 -IncludeCoverage` fails if coverage falls below the target. Current coverage is over 90% with 61 tests. `codecov.yml` also configures Codecov PR comments and 80% project/patch status targets.
+
+Unit tests cover pure utility behavior, CLI wrapper argument construction, retry handling, and the parallel fetcher. CLI calls are mocked where possible; the `Get-ItemDetails` runspace test uses a temporary `op.cmd` shim on `PATH` so worker runspaces can execute the production command shape without requiring a real 1Password session.
 
 Test fixtures are defined as script-level helper functions at the top of `tests\Utils.Tests.ps1`:
 
 - `New-FakeDetails` — builds a fake item details object with optional password, rotation field, recipe field, tags, and SSO field
 - `New-FakeLogin` — builds a fake item summary object with an id and title
+
+Run linting with:
+
+```powershell
+.\scripts\Lint.ps1
+```
+
+Known lint output currently includes warning-level findings only; CI treats the current wrapper exit status as authoritative.
+
+## CI and artifacts
+
+GitHub Actions runs lint and test/coverage jobs on pushes to `main` and pull requests. The coverage job installs Pester 5, runs `scripts\Test.ps1 -IncludeCoverage`, publishes `coverage/summary.txt` to the step summary, uploads `coverage/coverage.xml` to Codecov, and stores the `coverage/` directory as an artifact.
+
+Generated files under `coverage/` and exported `*.csv` files are ignored by Git.
 
 ## Known limitations
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,116 @@
 # 1password-review-scripts
 
-Administrative management scripts to configure, review, and update items stored in 1Password for security and organisation.
+PowerShell scripts for auditing and maintaining 1Password vault items. The scripts run locally against the 1Password CLI (`op`) and help identify untagged items, set password rotation metadata, find stale passwords, generate replacements, and export review data.
 
-## Setup
+## Requirements
 
-The scripts require:
-- A [1Password subscription](https://1password.com/).
-- The [1Password CLI](https://developer.1password.com/docs/cli) (op) installed and configured.
-- [PowerShell](https://github.com/PowerShell/PowerShell) (Core) 7.0 or newer is recommended for the best experience, although PowerShell 5.1 is supported.
+- 1Password CLI (`op`) installed and available on `PATH`.
+- An authenticated 1Password CLI session. Run `op signin` before using the scripts.
+- Windows PowerShell 5.1 for script execution. PowerShell 7+ is also used by CI and works for development tooling.
+- Pester 5+ for the unit test suite.
 
-On Windows, these scripts are designed to run in PowerShell.
+## Scripts
 
-## Management Scripts
+| Script | Purpose |
+| --- | --- |
+| `Get-Untagged-Items.ps1` | Lists login, password, and API credential items that have no meaningful tags. Tags matching `secure*` are treated as non-significant. |
+| `Add-Rotation-Fields.ps1` | Adds missing `last password update` metadata to items with passwords. It also reports SSO items that should receive the `secure/sso` tag. |
+| `Get-Stale-Items.ps1` | Lists items whose `last password update` date is older than the configured cadence for a tag. |
+| `New-Item-Password.ps1` | Generates a new password for one item and updates its rotation date. |
+| `Get-All-Items-Extended.ps1` | Exports a CSV inventory with security metadata, recipe, last password update, and age. |
 
-The following scripts have been developed to be run locally for management tasks.
+### Common Examples
 
-  Script                  |  Purpose
---------------------------|------------------------------------------------
-`Get-Untagged-Items.ps1`  | Identify items without tags to categorise
-`Add-Rotation-Fields.ps1` | Add metadata fields for password rotation scripts or SSO tags
-`Get-Stale-Items.ps1`     | Identify items due for password rotation by category
-`New-Item-Password.ps1`   | Generate new password for 1Password item and update metadata
+```powershell
+.\Get-Untagged-Items.ps1 -Vault private
+.\Add-Rotation-Fields.ps1 -Vault Shared
+.\Get-Stale-Items.ps1 -Vault Shared -Tag finance
+.\New-Item-Password.ps1 -Vault private -Item "My Login"
+.\Get-All-Items-Extended.ps1 -Vault Shared -ExportPath .\items.csv
+```
+
+Generated CSV files are ignored by Git.
+
+## Tags and Fields
+
+The scripts use tags to decide what should be audited or skipped:
+
+| Tag or pattern | Meaning |
+| --- | --- |
+| `other/*` | Exclude the item from rotation checks and setup. |
+| `secure/sso` | The item signs in through SSO and does not need password rotation. |
+| `secure*` | Treated as non-significant by the untagged-item audit. |
+| `finance`, `main` | Use a 90-day password rotation cadence. Other tags default to 360 days. |
+
+Custom fields are matched by label:
+
+| Field label | Used for |
+| --- | --- |
+| `last password update` | Unix timestamp date used by stale-item checks and exports. |
+| `password recipe` | Optional password generation recipe for `New-Item-Password.ps1`. |
+| `sign in with` | SSO detection for setup and extended export metadata. |
+
+## Password Recipes
+
+`New-Item-Password.ps1` reads the item-level `password recipe` field. If it is missing, the default is:
+
+```text
+words,digits,symbols,32
+```
+
+Recipes without `words` are passed directly to `op item edit --generate-password`. Recipes containing `words` use local memorable-password generation because the 1Password CLI does not generate word-based passwords. The word list is downloaded from EFF on first use and cached under `%LOCALAPPDATA%\1password-scripts\eff-wordlist.txt`.
+
+## Development
+
+Install the development modules in the PowerShell environment you use for testing:
+
+```powershell
+Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser
+Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+```
+
+Run checks with the helper scripts:
+
+```powershell
+.\scripts\Lint.ps1
+.\scripts\Test.ps1
+.\scripts\Test.ps1 -IncludeCoverage
+```
+
+The Makefile wraps the same commands when `make` is available:
+
+```powershell
+make lint
+make test
+make coverage
+make ci
+```
+
+## Testing and Coverage
+
+Unit tests live in `tests/Utils.Tests.ps1` and use Pester 5 syntax. The tests focus on pure utility behavior in `Utils.ps1`, with mocked `op` calls for CLI wrappers. Vault mutation commands remain integration concerns and are not run by the unit suite.
+
+Coverage is collected for `Utils.ps1`:
+
+```powershell
+.\scripts\Test.ps1 -IncludeCoverage
+```
+
+This writes:
+
+| File | Description |
+| --- | --- |
+| `coverage/test-results.xml` | JUnit-style test results. |
+| `coverage/coverage.xml` | JaCoCo coverage report uploaded by CI. |
+| `coverage/summary.txt` | Human-readable coverage summary. |
+| `coverage/missed-commands.txt` | Remaining uncovered commands, when any exist. |
+
+The local coverage target is 80%. CI uploads `coverage/coverage.xml` to Codecov, and `codecov.yml` configures PR comments plus 80% project and patch targets.
+
+## CI
+
+GitHub Actions runs two jobs on pushes to `main` and on pull requests:
+
+- `Lint` installs PSScriptAnalyzer and runs `scripts/Lint.ps1`.
+- `Test and coverage` installs Pester, runs `scripts/Test.ps1 -IncludeCoverage`, publishes the coverage summary, uploads Codecov data, and stores the coverage artifacts.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+coverage:
+  precision: 2
+  round: down
+  range: 80..100
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+        if_ci_failed: error
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+        if_ci_failed: error
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+  show_carryforward_flags: true

--- a/scripts/Test.ps1
+++ b/scripts/Test.ps1
@@ -2,7 +2,8 @@
 
 [CmdletBinding()]
 param(
-    [switch]$IncludeCoverage
+    [switch]$IncludeCoverage,
+    [double]$CoverageTarget = 80
 )
 
 $ErrorActionPreference = 'Stop'
@@ -19,26 +20,66 @@ $config = New-PesterConfiguration
 $config.Run.Path = $testPath
 $config.Run.Exit = $false # Handle exit manually to allow summary generation
 $config.Run.PassThru = $true # Return results object
-$config.TestResult.Enabled = $true
-$config.TestResult.OutputPath = Join-Path $reportDir 'test-results.xml'
-$config.TestResult.OutputFormat = 'NUnitXml'
+$config.TestResult.Enabled = $false
 
 if ($IncludeCoverage) {
     $config.CodeCoverage.Enabled = $true
     $config.CodeCoverage.Path = $coveragePath
+    $config.CodeCoverage.CoveragePercentTarget = $CoverageTarget
     $config.CodeCoverage.OutputPath = Join-Path $reportDir 'coverage.xml'
     $config.CodeCoverage.OutputFormat = 'JaCoCo'
 }
 
 $result = Invoke-Pester -Configuration $config
 
+$testResultPath = Join-Path $reportDir 'test-results.xml'
+$xml = New-Object System.Xml.XmlDocument
+$suite = $xml.CreateElement('testsuite')
+$suite.SetAttribute('name', 'Pester')
+$suite.SetAttribute('tests', [string]$result.TotalCount)
+$suite.SetAttribute('failures', [string]$result.FailedCount)
+$suite.SetAttribute('skipped', [string]$result.SkippedCount)
+$suite.SetAttribute('time', [string][math]::Round($result.Duration.TotalSeconds, 3))
+[void]$xml.AppendChild($suite)
+
+foreach ($test in @($result.Tests)) {
+    $case = $xml.CreateElement('testcase')
+    $case.SetAttribute('name', $test.ExpandedName)
+    $case.SetAttribute('classname', ($test.Block -join '.'))
+    $case.SetAttribute('time', [string][math]::Round($test.Duration.TotalSeconds, 3))
+
+    if ($test.Result -eq 'Failed') {
+        $failure = $xml.CreateElement('failure')
+        $failure.SetAttribute('message', $test.ErrorRecord.Exception.Message)
+        $failure.InnerText = $test.ErrorRecord.ScriptStackTrace
+        [void]$case.AppendChild($failure)
+    } elseif ($test.Result -eq 'Skipped') {
+        [void]$case.AppendChild($xml.CreateElement('skipped'))
+    }
+
+    [void]$suite.AppendChild($case)
+}
+
+$xml.Save($testResultPath)
+
 if ($IncludeCoverage.IsPresent) {
     $coverageReport = $result.CodeCoverage
     if ($null -eq $coverageReport) {
         Write-Warning 'Coverage was requested but no coverage data was returned.'
     } else {
-        # Pester 5 still uses these property names for the summary display
-        $pct = if ($coverageReport.NumberOfCommandsAnalyzed -gt 0) {
+        $analyzedCount = if ($null -ne $coverageReport.CommandsAnalyzedCount) {
+            $coverageReport.CommandsAnalyzedCount
+        } else {
+            $coverageReport.NumberOfCommandsAnalyzed
+        }
+        $executedCount = if ($null -ne $coverageReport.CommandsExecutedCount) {
+            $coverageReport.CommandsExecutedCount
+        } else {
+            $coverageReport.NumberOfCommandsExecuted
+        }
+        $pct = if ($null -ne $coverageReport.CoveragePercent) {
+            [math]::Round($coverageReport.CoveragePercent, 2)
+        } elseif ($analyzedCount -gt 0) {
             [math]::Round(($coverageReport.NumberOfCommandsExecuted / $coverageReport.NumberOfCommandsAnalyzed) * 100, 2)
         } else {
             0
@@ -46,7 +87,8 @@ if ($IncludeCoverage.IsPresent) {
 
         $summary = @(
             "Code coverage: $pct%"
-            "Commands covered: $($coverageReport.NumberOfCommandsExecuted) / $($coverageReport.NumberOfCommandsAnalyzed)"
+            "Commands covered: $executedCount / $analyzedCount"
+            "Coverage target: $CoverageTarget%"
             "File: Utils.ps1"
         ) -join [Environment]::NewLine
 
@@ -54,7 +96,11 @@ if ($IncludeCoverage.IsPresent) {
         $summaryPath = Join-Path $reportDir 'summary.txt'
         Set-Content -Path $summaryPath -Value $summary -Encoding UTF8
 
-        $missed = @($coverageReport.MissedCommands)
+        $missed = if ($null -ne $coverageReport.CommandsMissed) {
+            @($coverageReport.CommandsMissed)
+        } else {
+            @($coverageReport.MissedCommands)
+        }
         if ($missed.Count -gt 0) {
             $missedPath = Join-Path $reportDir 'missed-commands.txt'
             $missed |
@@ -62,6 +108,11 @@ if ($IncludeCoverage.IsPresent) {
                 Format-Table Function, Line, Command -AutoSize |
                 Out-String -Width 200 |
                 Set-Content -Path $missedPath -Encoding UTF8
+        }
+
+        if ($pct -lt $CoverageTarget) {
+            Write-Error "Code coverage $pct% is below the required $CoverageTarget% target."
+            exit 1
         }
     }
 }

--- a/tests/Utils.Tests.ps1
+++ b/tests/Utils.Tests.ps1
@@ -50,6 +50,139 @@ BeforeAll {
 
 # ── Get-ItemField ─────────────────────────────────────────────────────────────
 
+Describe "Get-VaultItems" {
+    It "passes filters to op and parses the item list" {
+        Mock op {
+            $script:CapturedOpArgs = $args
+            return '[{"id":"one","title":"One"}]'
+        }
+
+        $result = Get-VaultItems -Vault "private" -Categories @("login", "password") -Tag "finance" -Long
+
+        $result.Count | Should -Be 1
+        $result[0].id | Should -Be "one"
+        $script:CapturedOpArgs | Should -Contain "--vault"
+        $script:CapturedOpArgs | Should -Contain "private"
+        $script:CapturedOpArgs | Should -Contain "--categories"
+        $script:CapturedOpArgs | Should -Contain "login,password"
+        $script:CapturedOpArgs | Should -Contain "--tags"
+        $script:CapturedOpArgs | Should -Contain "finance"
+        $script:CapturedOpArgs | Should -Contain "--long"
+    }
+
+    It "omits optional filters when they are not supplied" {
+        Mock op {
+            $script:CapturedOpArgs = $args
+            return '[]'
+        }
+
+        $result = Get-VaultItems -Vault "private"
+
+        $result.Count | Should -Be 0
+        $script:CapturedOpArgs | Should -Contain "--vault"
+        $script:CapturedOpArgs | Should -Not -Contain "--categories"
+        $script:CapturedOpArgs | Should -Not -Contain "--tags"
+        $script:CapturedOpArgs | Should -Not -Contain "--long"
+    }
+}
+
+# ── Get-ItemDetail ────────────────────────────────────────────────────────────
+
+Describe "Test-OpTransientError" {
+    It "returns true for known transient op messages" {
+        Test-OpTransientError "request timed out while connecting to desktop app" | Should -Be $true
+    }
+
+    It "returns false for non-transient op messages" {
+        Test-OpTransientError "authentication required" | Should -Be $false
+    }
+}
+
+Describe "Get-ItemDetail" {
+    It "passes the vault to op and parses item details" {
+        Mock op {
+            $script:CapturedOpArgs = $args
+            $global:LASTEXITCODE = 0
+            return '{"id":"abc","title":"Example"}'
+        }
+
+        $result = Get-ItemDetail -Id "abc" -Vault "private"
+
+        $result.id | Should -Be "abc"
+        $script:CapturedOpArgs | Should -Contain "--vault"
+        $script:CapturedOpArgs | Should -Contain "private"
+    }
+
+    It "retries transient op failures before returning details" {
+        $script:AttemptCount = 0
+        Mock op {
+            $script:AttemptCount++
+            if ($script:AttemptCount -eq 1) {
+                $global:LASTEXITCODE = 1
+                return "timed out while connecting to desktop app"
+            }
+            $global:LASTEXITCODE = 0
+            return '{"id":"retry-ok"}'
+        }
+
+        $result = Get-ItemDetail -Id "retry-ok" -MaxRetries 2 -RetryDelayMs 0
+
+        $result.id | Should -Be "retry-ok"
+        $script:AttemptCount | Should -Be 2
+    }
+
+    It "throws non-transient op errors without retrying" {
+        $script:AttemptCount = 0
+        Mock op {
+            $script:AttemptCount++
+            $global:LASTEXITCODE = 1
+            return "authentication required"
+        }
+
+        { Get-ItemDetail -Id "abc" -MaxRetries 2 -RetryDelayMs 0 } | Should -Throw "*authentication required*"
+        $script:AttemptCount | Should -Be 1
+    }
+}
+
+# ── Get-ItemDetails ───────────────────────────────────────────────────────────
+
+Describe "Get-ItemDetails" {
+    It "returns an empty array when no items are supplied" {
+        $result = Get-ItemDetails -Items @()
+        $result.Count | Should -Be 0
+    }
+
+    It "fetches item details in worker runspaces" {
+        $shimDir = Join-Path $TestDrive "bin"
+        New-Item -ItemType Directory -Path $shimDir | Out-Null
+        $opShim = Join-Path $shimDir "op.cmd"
+        @(
+            "@echo off"
+            "echo {""id"":""%5"",""title"":""Title %5""}"
+        ) | Set-Content -Path $opShim -Encoding ASCII
+
+        $oldPath = $env:PATH
+        $env:PATH = "$shimDir;$oldPath"
+
+        try {
+            $items = @(
+                [PSCustomObject]@{ id = "one"; title = "One" },
+                [PSCustomObject]@{ id = "two"; title = "Two" }
+            )
+
+            $result = Get-ItemDetails -Items $items -ThrottleLimit 2
+
+            $result.Count | Should -Be 2
+            $result[0].Login.title | Should -Be "One"
+            $result[0].Details.id | Should -Be "one"
+            $result[1].Login.title | Should -Be "Two"
+            $result[1].Details.id | Should -Be "two"
+        } finally {
+            $env:PATH = $oldPath
+        }
+    }
+}
+
 Describe "Get-ItemField" {
     It "returns field when found by id" {
         $details = New-FakeDetails -WithPassword
@@ -327,6 +460,30 @@ Describe "Get-WordList" {
         $result | Should -Contain "bird"
     }
 
+    It "creates the cache directory when it is missing" {
+        $testCache = Join-Path (Join-Path $TestDrive "nested") "wordlist.txt"
+        Mock Invoke-WebRequest {
+            [PSCustomObject]@{ Content = "11111`table`n11112`tbird`n" }
+        }
+
+        $result = Get-WordList -CachePath $testCache
+
+        Test-Path (Split-Path $testCache) | Should -Be $true
+        Test-Path $testCache | Should -Be $true
+        $result | Should -Contain "able"
+    }
+
+    It "reads words from an existing cache" {
+        $testCache = Join-Path $TestDrive "cached-read.txt"
+        @("able", "bird") | Out-File $testCache -Encoding UTF8
+        Mock Invoke-WebRequest { throw "Should not download" }
+
+        $result = Get-WordList -CachePath $testCache
+
+        $result | Should -Contain "able"
+        $result | Should -Contain "bird"
+    }
+
     It "does not download when cache already exists" {
         $testCache = Join-Path $TestDrive "cached.txt"
         @("able", "bird") | Out-File $testCache -Encoding UTF8
@@ -425,5 +582,12 @@ Describe "New-MemorablePassword" {
         $result = New-MemorablePassword -RecipeParts @("words", "digits") -Length 13
         $result.Length | Should -Be 13
         $result | Should -Match '\d'
+    }
+
+    It "fills a short words-only password with lowercase letters when no word fits" {
+        $result = New-MemorablePassword -RecipeParts @("words") -Length 2
+
+        $result.Length | Should -Be 2
+        $result | Should -Match '^[a-z]{2}$'
     }
 }


### PR DESCRIPTION
## Summary
- expand Pester 5 unit coverage for Utils.ps1, including CLI wrapper and runspace detail-fetch paths
- add an 80% coverage gate plus Codecov PR comment/status configuration
- expand README and AGENTS context with scripts, testing, coverage, CI, and development docs

## Verification
- pwsh -NoProfile -File scripts\\Lint.ps1
- pwsh -NoProfile -File scripts\\Test.ps1 -IncludeCoverage (61 passed, 91.84% coverage)